### PR TITLE
packaging(rpm): threshold.spec + Fedora 43/44 CI and release jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -204,7 +204,7 @@ jobs:
         run: |
           V=$(sed -n "s/.*version: '\([0-9.]*\)'.*/\1/p" meson.build | head -1)
           mkdir -p rpmbuild/{SOURCES,SPECS,RPMS,SRPMS,BUILD}
-          tar --exclude=.git --transform "s,^\.,Threshold-$V," \
+          tar --exclude=.git --exclude=rpmbuild --transform "s,^\.,Threshold-$V," \
               -czf rpmbuild/SOURCES/Threshold-$V.tar.gz .
           cp packaging/threshold.sysusers rpmbuild/SOURCES/
           cp packaging/threshold.spec rpmbuild/SPECS/

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -182,3 +182,44 @@ jobs:
           name: threshold-build-debian-13
           path: builddir/
           retention-days: 7
+
+  rpm-package:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        fedora: ['43', '44']
+    container: fedora:${{ matrix.fedora }}
+    steps:
+      - name: Install build dependencies
+        run: |
+          dnf -y install git rpm-build \
+            meson ninja-build pkgconf-pkg-config gettext blueprint-compiler \
+            gtk4-devel libadwaita-devel python3-devel python3-gobject \
+            desktop-file-utils libappstream-glib systemd-rpm-macros
+
+      - uses: actions/checkout@v4
+
+      - name: Build SRPM and RPMs
+        run: |
+          V=$(sed -n "s/.*version: '\([0-9.]*\)'.*/\1/p" meson.build | head -1)
+          mkdir -p rpmbuild/{SOURCES,SPECS,RPMS,SRPMS,BUILD}
+          tar --exclude=.git --transform "s,^\.,Threshold-$V," \
+              -czf rpmbuild/SOURCES/Threshold-$V.tar.gz .
+          cp packaging/threshold.sysusers rpmbuild/SOURCES/
+          cp packaging/threshold.spec rpmbuild/SPECS/
+          rpmbuild -ba --define "_topdir $PWD/rpmbuild" rpmbuild/SPECS/threshold.spec
+
+      - name: Collect artifacts
+        run: |
+          mkdir -p artifacts
+          cp rpmbuild/RPMS/noarch/*.rpm artifacts/
+          ls -l artifacts/
+
+      - name: Upload RPM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: threshold-rpm-fedora-${{ matrix.fedora }}
+          path: artifacts/*.rpm
+          retention-days: 14
+          if-no-files-found: error

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -9,7 +9,7 @@ permissions:
   contents: write
 
 jobs:
-  release:
+  deb:
     runs-on: ubuntu-24.04
     steps:
       - uses: actions/checkout@v4
@@ -31,25 +31,81 @@ jobs:
       - name: Lintian
         run: lintian artifacts/*.deb
 
-      - name: Generate checksums
-        run: |
-          cd artifacts
-          sha256sum *.deb > SHA256SUMS
-          cat SHA256SUMS
-
-      - name: Upload artifacts
+      - name: Upload .deb artifacts
         uses: actions/upload-artifact@v4
         with:
           name: release-debs
-          path: artifacts/
-          retention-days: 30
+          path: artifacts/*.deb
+          retention-days: 5
           if-no-files-found: error
+
+  rpm:
+    runs-on: ubuntu-24.04
+    strategy:
+      fail-fast: false
+      matrix:
+        fedora: ['43', '44']
+    container: fedora:${{ matrix.fedora }}
+    steps:
+      - name: Install build dependencies
+        run: |
+          dnf -y install git rpm-build \
+            meson ninja-build pkgconf-pkg-config gettext blueprint-compiler \
+            gtk4-devel libadwaita-devel python3-devel python3-gobject \
+            desktop-file-utils libappstream-glib systemd-rpm-macros
+
+      - uses: actions/checkout@v4
+
+      - name: Build SRPM and RPMs
+        run: |
+          V=$(sed -n "s/.*version: '\([0-9.]*\)'.*/\1/p" meson.build | head -1)
+          mkdir -p rpmbuild/{SOURCES,SPECS,RPMS,SRPMS,BUILD}
+          tar --exclude=.git --transform "s,^\.,Threshold-$V," \
+              -czf rpmbuild/SOURCES/Threshold-$V.tar.gz .
+          cp packaging/threshold.sysusers rpmbuild/SOURCES/
+          cp packaging/threshold.spec rpmbuild/SPECS/
+          rpmbuild -ba --define "_topdir $PWD/rpmbuild" rpmbuild/SPECS/threshold.spec
+
+      - name: Collect artifacts
+        run: |
+          mkdir -p artifacts
+          cp rpmbuild/RPMS/noarch/*.rpm artifacts/
+          ls -l artifacts/
+
+      - name: Upload RPM artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: release-rpm-fedora-${{ matrix.fedora }}
+          path: artifacts/*.rpm
+          retention-days: 5
+          if-no-files-found: error
+
+  release:
+    needs: [deb, rpm]
+    runs-on: ubuntu-24.04
+    steps:
+      - uses: actions/download-artifact@v4
+        with:
+          path: dist
+
+      - name: Stage release files
+        run: |
+          mkdir -p release
+          find dist -type f \( -name '*.deb' -o -name '*.rpm' \) -exec cp {} release/ \;
+          ls -l release/
+
+      - name: Generate checksums
+        run: |
+          cd release
+          sha256sum *.deb *.rpm > SHA256SUMS
+          cat SHA256SUMS
 
       - name: Publish GitHub Release
         uses: softprops/action-gh-release@v2
         with:
           files: |
-            artifacts/threshold_*.deb
-            artifacts/SHA256SUMS
+            release/*.deb
+            release/*.rpm
+            release/SHA256SUMS
           generate_release_notes: true
           draft: true

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ jobs:
         run: |
           V=$(sed -n "s/.*version: '\([0-9.]*\)'.*/\1/p" meson.build | head -1)
           mkdir -p rpmbuild/{SOURCES,SPECS,RPMS,SRPMS,BUILD}
-          tar --exclude=.git --transform "s,^\.,Threshold-$V," \
+          tar --exclude=.git --exclude=rpmbuild --transform "s,^\.,Threshold-$V," \
               -czf rpmbuild/SOURCES/Threshold-$V.tar.gz .
           cp packaging/threshold.sysusers rpmbuild/SOURCES/
           cp packaging/threshold.spec rpmbuild/SPECS/

--- a/.gitignore
+++ b/.gitignore
@@ -1,6 +1,7 @@
 /docs/superpowers/*
 /AGENTS.md
 /builddir/
+/rpmbuild/
 /obj-*/
 /artifacts/
 /debian/.debhelper/

--- a/packaging/threshold.spec
+++ b/packaging/threshold.spec
@@ -118,7 +118,8 @@ fi
 %{_datadir}/GConf/gsettings/com.bongbetic.batteryguard.convert
 %{_datadir}/icons/hicolor/scalable/apps/com.bongbetic.threshold.svg
 %{_datadir}/icons/hicolor/symbolic/apps/com.bongbetic.threshold-symbolic.svg
-%{_datadir}/locale/*/LC_MESSAGES/*.mo
+# po/LINGUAS is empty — no .mo installed yet; re-add
+# %%{_datadir}/locale/*/LC_MESSAGES/*.mo when translations land
 %{_udevrulesdir}/99-msi-battery.rules
 %{_sysusersdir}/threshold.conf
 

--- a/packaging/threshold.spec
+++ b/packaging/threshold.spec
@@ -1,0 +1,133 @@
+# Spec for the GitHub-Release RPM of Threshold (charter: map #35 — not COPR,
+# not official Fedora). Layout mirrors debian/ packaging; research notes with
+# primary-source citations: docs/research/fedora-packaging.md (ticket #43).
+
+%global msi_ec_ver 0.13.112
+
+Name:           threshold
+Version:        1.4.1
+Release:        1%{?dist}
+Summary:        Battery charge threshold controller for Linux laptops
+License:        GPL-3.0-or-later
+URL:            https://github.com/Bongbetic/Threshold
+Source0:        %{url}/archive/v%{version}/Threshold-%{version}.tar.gz
+Source1:        threshold.sysusers
+BuildArch:      noarch
+
+BuildRequires:  meson
+BuildRequires:  ninja-build
+BuildRequires:  pkgconf-pkg-config
+BuildRequires:  gettext
+BuildRequires:  blueprint-compiler
+BuildRequires:  gtk4-devel >= 4.14
+BuildRequires:  libadwaita-devel >= 1.5
+BuildRequires:  python3-devel
+BuildRequires:  python3-gobject
+BuildRequires:  desktop-file-utils
+BuildRequires:  libappstream-glib
+BuildRequires:  systemd-rpm-macros
+
+Requires:       python3-gobject
+Requires:       gtk4 >= 4.14
+Requires:       libadwaita >= 1.5
+Requires:       libnotify
+Requires:       hicolor-icon-theme
+Recommends:     %{name}-msi-ec-dkms
+Recommends:     polkit
+
+%description
+Threshold provides a GTK4 graphical interface for setting the battery
+charge threshold on Linux laptops. When the msi-ec kernel module is
+available the charge limit is written directly to the EC microcontroller
+and persists across reboots. When no EC/sysfs charge control is available
+the application falls back to a notification alarm that alerts the user
+once the charge threshold is reached.
+
+%package msi-ec-dkms
+Summary:        DKMS source for the bundled msi-ec kernel module
+BuildArch:      noarch
+Requires:       dkms
+Requires(post): dkms
+Requires(preun): dkms
+
+%description msi-ec-dkms
+Bundled msi-ec %{msi_ec_ver} kernel module source, built against the running
+kernel at install time via DKMS (mirrors the Debian package's /usr/src
+bundle). On Secure Boot systems the module must be signed (MOK) to load.
+
+%prep
+%autosetup -p1 -n Threshold-%{version}
+# Fedora has no plugdev group: rewrite the Debian-ism to our sysusers.d group
+# (see research notes §5). sed touches the RUN+= chgrp lines and the comments.
+sed -i 's/\bplugdev\b/threshold/g' data/99-msi-battery.rules
+
+%build
+%meson
+%meson_build
+
+%install
+%meson_install
+# Python lives in %%{_datadir}, not sitelib — brp does not cover it (§1)
+%py_byte_compile %{python3} %{buildroot}%{_datadir}/com.bongbetic.threshold/threshold/
+
+# Dedicated system group instead of plugdev (§5.3)
+install -Dpm 0644 %{SOURCE1} %{buildroot}%{_sysusersdir}/threshold.conf
+
+# DKMS source bundle → /usr/src, same as the .deb
+mkdir -p %{buildroot}%{_usrsrc}/msi-ec-%{msi_ec_ver}
+cp -a msi-ec-src/. %{buildroot}%{_usrsrc}/msi-ec-%{msi_ec_ver}/
+
+# Autoload hint
+mkdir -p %{buildroot}%{_modulesloaddir}
+echo msi-ec > %{buildroot}%{_modulesloaddir}/msi-ec.conf
+
+%check
+desktop-file-validate %{buildroot}%{_datadir}/applications/com.bongbetic.threshold.desktop
+appstream-util validate-relax %{buildroot}%{_metainfodir}/com.bongbetic.threshold.metainfo.xml
+
+# No icon-cache/desktop-database/gschema-compile scriptlets: RPM file triggers
+# owned by hicolor-icon-theme/desktop-file-utils/glib2 refresh those caches (§4).
+%post
+udevadm control --reload || :
+udevadm trigger --subsystem-match=power_supply || :
+
+%post msi-ec-dkms
+if command -v dkms >/dev/null 2>&1; then
+    dkms add    -m msi-ec -v %{msi_ec_ver} || :
+    dkms build  -m msi-ec -v %{msi_ec_ver} || :
+    dkms install -m msi-ec -v %{msi_ec_ver} || :
+fi
+modprobe msi-ec || :
+# Secure Boot: unsigned module will not load; enroll a MOK key:
+#   sudo mokutil --import /var/lib/shim-signed/mok/mok.pub && reboot
+
+%preun msi-ec-dkms
+if [ "$1" = "0" ]; then
+    dkms remove -m msi-ec -v %{msi_ec_ver} --all || :
+fi
+
+%files
+%license LICENSE
+%doc README.md
+%{_bindir}/threshold
+%{_datadir}/com.bongbetic.threshold/
+%{_datadir}/applications/com.bongbetic.threshold.desktop
+%{_metainfodir}/com.bongbetic.threshold.metainfo.xml
+%{_datadir}/glib-2.0/schemas/com.bongbetic.threshold.gschema.xml
+%{_datadir}/glib-2.0/schemas/com.bongbetic.batteryguard.gschema.xml
+%{_datadir}/GConf/gsettings/com.bongbetic.batteryguard.convert
+%{_datadir}/icons/hicolor/scalable/apps/com.bongbetic.threshold.svg
+%{_datadir}/icons/hicolor/symbolic/apps/com.bongbetic.threshold-symbolic.svg
+%{_datadir}/locale/*/LC_MESSAGES/*.mo
+%{_udevrulesdir}/99-msi-battery.rules
+%{_sysusersdir}/threshold.conf
+
+%files msi-ec-dkms
+%{_usrsrc}/msi-ec-%{msi_ec_ver}/
+%{_modulesloaddir}/msi-ec.conf
+
+%changelog
+* Fri Aug 28 2026 Soubarna <Soubarna@live.in> - 1.4.1-1
+- Initial Fedora RPM: sysusers.d group threshold replaces plugdev, manual
+  %%py_byte_compile for the /usr/share python tree, DKMS subpackage for the
+  bundled msi-ec %{msi_ec_ver} source, no cache scriptlets (RPM file triggers)

--- a/packaging/threshold.sysusers
+++ b/packaging/threshold.sysusers
@@ -1,0 +1,2 @@
+# Type Name       ID  GECOS
+g      threshold  -


### PR DESCRIPTION
Resolves #44 (map #35).

- packaging/threshold.spec: noarch main pkg + threshold-msi-ec-dkms subpackage mirroring the .deb — sysusers.d group threshold replaces plugdev, manual %py_byte_compile for the /usr/share python tree, zero cache scriptlets (RPM file triggers own them), %check validates desktop + metainfo
- packaging/threshold.sysusers: Source1 group-only account
- ci.yml: rpm-package matrix job (fedora:43/44 containers, rpmbuild -ba) — both green on this branch, artifacts threshold-rpm-fedora-43/44 produced
- release.yml: deb + rpm jobs feed a publish job attaching .deb/.rpm + combined SHA256SUMS to a draft GitHub Release

Content-verified against the CI-built fc44 RPM (file list, udev sed, sysusers, DKMS tree). Research basis: docs/research/fedora-packaging.md (#43).

Note: overall CI stays red from the pre-existing E501 lint failure on main (5fb0fb3) — untouched by this branch.
