### PR TITLE
docs: Fedora RPM install guide + verification checklist

### DIFF
--- a/INSTALL.md
+++ b/INSTALL.md
@@ -12,14 +12,18 @@ also supported — the app detects the appropriate control mode automatically.
 When no EC/sysfs charge control is available, Threshold falls back to a
 notification alarm.
 
-## Supported Ubuntu versions
+## Supported distributions
 
-Packages are built and tested on **Ubuntu 24.04 LTS (noble)** and
-**Ubuntu 26.04 LTS (resolute)**.  The package is built for `amd64`.
+| Distribution | Package | Notes |
+|---|---|---|
+| Ubuntu 24.04 LTS (noble), 26.04 LTS (resolute), Debian trixie | `threshold_*.deb` | `amd64` |
+| Fedora 43, Fedora 44 | `threshold-*.rpm` | `noarch` — app + DKMS subpackage |
 
 ---
 
 ## Install from a GitHub Release (recommended)
+
+### Ubuntu / Debian (.deb)
 
 1. Open the
    [Releases page](https://github.com/Bongbetic/MSI-batteryguard-for-Thin-A15-B7UCX/releases)
@@ -30,7 +34,7 @@ Packages are built and tested on **Ubuntu 24.04 LTS (noble)** and
 2. Install the package:
 
    ```bash
-   sudo apt install ./threshold_1.3.0-1_amd64.deb
+   sudo apt install ./threshold_1.4.1-1_amd64.deb
    ```
 
    DKMS builds the msi-ec module for the running kernel automatically. If
@@ -56,6 +60,60 @@ Packages are built and tested on **Ubuntu 24.04 LTS (noble)** and
    threshold
    ```
 
+### Fedora (.rpm)
+
+Two packages are attached to each release (built for Fedora 43 and 44):
+
+- `threshold-<version>-1.fcXX.noarch.rpm` — the GTK4 app
+- `threshold-msi-ec-dkms-<version>-1.fcXX.noarch.rpm` — the `msi-ec` DKMS
+  source; pulled in automatically by `dnf` as a weak dependency (install
+  it explicitly if you run with `--setopt=install_weak_deps=False`)
+
+1. Install the kernel-module prerequisites, then the app (the DKMS
+   subpackage comes with it and builds the `msi-ec` module for the
+   running kernel at install time; DKMS also rebuilds it on kernel
+   updates):
+
+   ```bash
+   sudo dnf install -y dkms "kernel-devel-uname-r == $(uname -r)"
+   sudo dnf install ./threshold-1.4.1-1.fc44.noarch.rpm
+   ```
+
+2. The package creates a system group `threshold` (Fedora has no
+   `plugdev`) and the udev rule grants that group write access to the
+   charge threshold attribute. Add yourself and log back in:
+
+   ```bash
+   sudo usermod -aG threshold $USER
+   # log out and back in for the group to take effect
+   ```
+
+   Users not in the `threshold` group can still apply thresholds through
+   the app's `pkexec` (polkit) fallback.
+
+3. **Secure Boot**: the unsigned DKMS module will not load until signed.
+   Enroll a MOK key once (for example, if one was created during DKMS
+   setup), then reboot:
+
+   ```bash
+   sudo mokutil --import /var/lib/shim-signed/mok/mok.pub
+   ```
+
+4. Launch from the app menu (**Threshold**) or:
+
+   ```bash
+   threshold
+   ```
+
+#### Fedora differences
+
+- udev rule group: `threshold` (rewritten from the Debian `plugdev` at
+  build time)
+- group config: `/usr/lib/sysusers.d/threshold.conf`
+- DKMS source: `/usr/src/msi-ec-0.13.112/`
+- autoload hint: `/usr/lib/modules-load.d/msi-ec.conf`
+- everything else matches the table below
+
 ### What gets installed
 
 | Component | Location |
@@ -79,13 +137,26 @@ The app automatically detects which control mode applies:
 
 ---
 
+## Verify downloads
+
+Every release carries a `SHA256SUMS` file covering the `.deb` and `.rpm`
+artifacts:
+
+```bash
+sha256sum -c SHA256SUMS --ignore-missing
+```
+
+A GPG-signed copy is maintained in the repository at
+`output/SHA256SUMS.asc`; verify it with `gpg --verify output/SHA256SUMS.asc`.
+
 ## Verify the module
 
-After installing `msi-ec-dkms`, load and check:
+After installing the DKMS package (`msi-ec-dkms` on Ubuntu/Debian,
+`threshold-msi-ec-dkms` on Fedora), load and check:
 
 ```bash
 sudo modprobe msi-ec
-dkms status                     # msi-ec/0.13 should be built + installed
+dkms status                     # msi-ec/0.13 (deb) or msi-ec/0.13.112 (rpm) built + installed
 modinfo msi-ec | grep filename # should point at updates/dkms, not the built-in path
 ls /sys/class/power_supply/BAT*/charge_control_end_threshold
 ```
@@ -100,6 +171,7 @@ If you prefer the latest upstream module instead of the packaged snapshot:
 
 ```bash
 sudo apt install -y git dkms linux-headers-$(uname -r)
+# Fedora: sudo dnf install -y git dkms "kernel-devel-uname-r == $(uname -r)"
 
 git clone https://github.com/BeardOverflow/msi-ec.git
 cd msi-ec
@@ -129,6 +201,13 @@ sudo apt install -y \
   gobject-introspection python3 python3-gi python3-pytest \
   blueprint-compiler libgtk-4-dev libadwaita-1-dev \
   gir1.2-gtk-4.0 gir1.2-adw-1
+```
+
+Fedora build dependencies:
+
+```bash
+sudo dnf install -y meson ninja-build gettext blueprint-compiler \
+  gtk4-devel libadwaita-devel python3-gobject desktop-file-utils
 ```
 
 Configure, test, install:
@@ -170,5 +249,7 @@ A single `.deb` lands in the parent directory:
 | `dkms status` shows build failure | Install `linux-headers-$(uname -r)` and reinstall the package |
 | Threshold file not found | Module loaded but EC not supported — app switches to notification mode |
 | Permission denied writing threshold | udev rule / `plugdev` membership — reload rules, re-login |
+| Permission denied writing threshold (Fedora) | `threshold` group membership (not `plugdev`) — `usermod -aG threshold $USER`, re-login |
+| DKMS module won't load (Secure Boot) | Sign and enroll a MOK key — see "Fedora (.rpm)" above |
 | App missing from GNOME Software | Ensure metainfo installed; refresh Software / AppStream cache |
 | App shows "Notification only" mode | No EC/sysfs threshold control — alarm monitors charge and notifies at threshold |

--- a/README.md
+++ b/README.md
@@ -51,29 +51,36 @@ Slider → Apply → /sys/class/power_supply/BAT*/charge_control_end_threshold
 
 ## Install
 
-Download the latest `.deb` from
-**[Releases](https://github.com/Bongbetic/Threshold/releases/latest)**
-and install:
+Download the latest package from
+**[Releases](https://github.com/Bongbetic/Threshold/releases/latest)**:
+
+**Ubuntu / Debian** (`threshold_<version>_amd64.deb`):
 
 ```bash
-sudo apt install ./threshold_1.4.0-1_amd64.deb
+sudo apt install ./threshold_1.4.1-1_amd64.deb
+sudo usermod -aG plugdev $USER   # log out and back in
 ```
 
-The package includes:
+**Fedora 43 / 44** (`threshold-<version>-1.fcXX.noarch.rpm`):
+
+```bash
+sudo dnf install -y dkms "kernel-devel-uname-r == $(uname -r)"
+sudo dnf install ./threshold-1.4.1-1.fc44.noarch.rpm
+sudo usermod -aG threshold $USER   # log out and back in
+```
+
+Every package includes:
 - The Threshold GTK4 app
 - Desktop entry and icons
-- A udev rule for passwordless threshold writes (`plugdev` group)
+- A udev rule for passwordless threshold writes (`plugdev` group on
+  Debian/Ubuntu, `threshold` group on Fedora)
 - The `msi-ec` DKMS source tree (built automatically on install)
 
-Add your user to the `plugdev` group (log out and back in):
+Launch from the app menu or run `threshold`. Full walkthrough, Secure
+Boot notes and download verification: **[INSTALL.md](INSTALL.md)**.
 
-```bash
-sudo usermod -aG plugdev $USER
-```
-
-Launch from the app menu or run `threshold`.
-
-> **Supported:** Ubuntu 24.04 LTS, 26.04 LTS, Debian Trixie — `amd64` only.
+> **Supported:** Ubuntu 24.04 LTS, 26.04 LTS, Debian Trixie (`amd64`);
+> Fedora 43, 44.
 
 ## Usage
 
@@ -104,8 +111,8 @@ Settings are also saved automatically when you click **Apply Threshold**.
 
 ## Building from source
 
-See **[INSTALL.md](INSTALL.md)** for the Meson build setup and local `.deb`
-packaging.
+See **[INSTALL.md](INSTALL.md)** for the Meson build setup and local
+`.deb`/`.rpm` packaging.
 
 ---
 

--- a/docs/verification/fedora-rpm.md
+++ b/docs/verification/fedora-rpm.md
@@ -1,0 +1,70 @@
+# Fedora RPM verification checklist
+
+Reusable procedure for verifying a Fedora RPM release. The bar was decided
+on the map's checklist ticket; the release cut itself runs this and records
+the evidence.
+
+**Bar for "verified": full coverage of checks A–E, proven on Fedora 43 +
+Fedora 44 via split environments, with one CI gate.**
+
+## Checks
+
+### A — Package install
+
+- `sudo dnf install ./threshold-<version>-1.fcXX.noarch.rpm` succeeds on a
+  clean system (the `threshold-msi-ec-dkms` subpackage installs
+  alongside).
+- Files present under `/usr/share/com.bongbetic.threshold/`.
+- `desktop-file-validate` passes on the installed desktop entry.
+
+### B — Permissions
+
+- sysusers group exists: `getent group threshold`.
+- udev rule rewritten `plugdev` → `threshold` and applied:
+  `grep threshold /usr/lib/udev/rules.d/99-msi-battery.rules`; the
+  package `%post` already reloads rules — re-run
+  `sudo udevadm control --reload-rules && sudo udevadm trigger` if in
+  doubt.
+- Threshold write works **without sudo** as a group member (after
+  re-login).
+- **pkexec fallback** works as a non-member.
+
+### C — App
+
+- Window launches (GTK4/libadwaita): run `threshold`.
+- Tray icon appears (StatusNotifierItem). GNOME VMs need an AppIndicator
+  extension for this check.
+- Notification fires (arm an alarm above the current charge and let it
+  trigger).
+
+### D — Kernel (hardware-bound; needs the MSI EC)
+
+- DKMS builds against the running kernel: `dkms status` shows
+  `msi-ec/0.13.112` installed.
+- Module loads (signed on Secure Boot systems): `sudo modprobe msi-ec`,
+  `modinfo msi-ec | grep filename`.
+- Attribute exists:
+  `ls /sys/class/power_supply/BAT1/charge_control_end_threshold`.
+- Write round-trip: `echo 80 | sudo tee .../charge_control_end_threshold`
+  → readback 80.
+
+### E — Lifecycle
+
+- `sudo dnf remove threshold threshold-msi-ec-dkms` removes the files and
+  the DKMS module cleanly (`dkms status` no longer lists msi-ec).
+- Reinstall works.
+
+## Environments (split)
+
+| Environment | Checks | Notes |
+|---|---|---|
+| CI smoke job (`release.yml`, Fedora 43 + 44 containers) | most of A, parts of B/E | install, assert group/udev/files/`SHA256SUMS`, remove clean; runs on every release |
+| Fedora 43 VM | A, B, C, E | D skipped (hardware-bound). GNOME needs the AppIndicator extension for the tray check. |
+| Fedora 44 bare metal (MSI Thin A15, Xfce, Secure Boot **on**) | A–E full | D needs one-time DKMS MOK signing setup (`/etc/dkms/framework.conf` had no signing config at the time of writing). Then install `threshold-msi-ec-dkms` and confirm build/load/attr/write. MOK enrollment keeps Secure Boot on — do not verify with SB off. |
+
+## Evidence
+
+Record run results in the "Cut the release and run verification" ticket
+resolution and in the GitHub Release notes. A release page counts as
+verified only once both the Fedora 43 and Fedora 44 results are recorded
+against it.


### PR DESCRIPTION
Part of the Fedora RPM release map (#35), resolves the docs/checksums task (#47).

- **INSTALL.md**: new "Fedora (.rpm)" install path — `dnf install` of `threshold` + `threshold-msi-ec-dkms` (weak dep), `kernel-devel-uname-r` prereqs, `threshold` sysusers group + udev story (no `plugdev` on Fedora), pkexec fallback, DKMS + MOK/Secure Boot notes, Fedora path differences, "Verify downloads" section (release `SHA256SUMS` + signed `output/SHA256SUMS.asc`), Fedora build deps and troubleshooting rows. Supported-distributions table now lists Fedora 43/44.
- **README.md**: install section covers both packages with per-distro group (`plugdev` vs `threshold`); supported line adds Fedora 43/44.
- **docs/verification/fedora-rpm.md**: reusable A–E checklist + split environments (CI smoke / F43 VM / F44 bare metal w/ MOK) from the verified-install checklist decision.

Checksum note: the actual `.rpm` lines in `output/SHA256SUMS`(+`.asc`) can only exist once release artifacts do, so that update is wired as an explicit cut-time step on "Cut the release and run verification" (#46).