### PR TITLE
Fix E501 lint regression so main CI is green

### DIFF
--- a/src/threshold/window.py
+++ b/src/threshold/window.py
@@ -412,7 +412,11 @@ class ThresholdWindow(Adw.ApplicationWindow):
                     _("msi-ec loaded but not controlling battery — check EC firmware support"),
                     is_error=True,
                 )
-                print("Threshold: msi-ec platform exists but mode is notify-only — check firmware whitelist", file=sys.stderr)
+                print(
+                    "Threshold: msi-ec platform exists but mode is notify-only"
+                    " — check firmware whitelist",
+                    file=sys.stderr,
+                )
 
     def _start_polling(self):
         """Start 5-second polling for battery charge refresh."""
@@ -586,7 +590,10 @@ class ThresholdWindow(Adw.ApplicationWindow):
                 actual = read_sysfs(bat_path / 'charge_control_end_threshold')
                 if actual is not None and int(actual) != value:
                     message = f'{message} (EC stored {actual}%)'
-                    print(f"Threshold: EC stored {actual}% differs from requested {value}%", file=sys.stderr)
+                    print(
+                        f"Threshold: EC stored {actual}% differs from requested {value}%",
+                        file=sys.stderr,
+                    )
             self._config.set_charge_threshold(value)
             self._config.set_last_applied_time(int(datetime.now().timestamp()))
             self.last_changed_label.set_label(
@@ -670,7 +677,10 @@ class ThresholdWindow(Adw.ApplicationWindow):
                 actual = read_sysfs(bat_path / 'charge_control_end_threshold')
                 if actual is not None and int(actual) != 100:
                     message = f'{message} (EC stored {actual}%)'
-                    print(f"Threshold: EC stored {actual}% differs from requested 100%", file=sys.stderr)
+                    print(
+                        f"Threshold: EC stored {actual}% differs from requested 100%",
+                        file=sys.stderr,
+                    )
             self.charge_scale.set_value(100)
             self.charge_value_label.set_label('100%')
             self._sync_presets(100)


### PR DESCRIPTION
Closes #49.

## Question

Fix the flake8 E501 failure(s) at `src/threshold/window.py` (lines 415, 589, 673 — 126/109/105 > 100 chars, red since 5fb0fb3) so CI runs go green overall again, letting the release-cut and verification tickets (#46, #50) read whole-run conclusions instead of squinting past a red lint job.

## Answer

Three over-long `print(...)` calls, not one — full-repo `flake8` after fixing the named line surfaced the other two (589, 673), same pattern since 5fb0fb3.

- Each `print()` wrapped across lines; one string split via implicit concatenation.
- Verified: `flake8 src/threshold tests` clean (CI's exact scope), `py_compile` passes, probe run shows byte-identical output for all three messages.
- Local full-repo flake8 also flags gitignored `debian/` build artifacts and `prototype-gtk4-ui/` (F401); both out of CI scope (`flake8 src/threshold tests`) and left alone.